### PR TITLE
Fix page titles

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,6 +1,12 @@
 import pluginWebc from "@11ty/eleventy-plugin-webc";
 
 export default function (eleventyConfig) {
+  eleventyConfig.addShortcode("pageTitle", function (title) {
+    const base = "Carlo Trimarchi";
+    const fallback = `${base} | Software Engineer`;
+    return title ? `${title} | ${base}` : fallback;
+  });
+
   eleventyConfig.addCollection("works", function (collectionApi) {
     const result = collectionApi.getFilteredByGlob("src/work/*.md");
     console.log(result);

--- a/src/_includes/layout.webc
+++ b/src/_includes/layout.webc
@@ -1,5 +1,4 @@
 ---
-title: Carlo Trimarchi | Software Engineer
 baseUrl: "{{ baseUrl }}"
 ---
 
@@ -8,7 +7,7 @@ baseUrl: "{{ baseUrl }}"
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title @raw="title"></title>
+	<title @raw="pageTitle(title)"></title>
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@200..900&display=swap" rel="stylesheet" webc:keep>

--- a/src/assets/css/_grid.css
+++ b/src/assets/css/_grid.css
@@ -65,6 +65,10 @@
     grid-template-columns: 120px 1fr 120px;
   }
 
+  .grid__content {
+    padding: var(--space-l);
+  }
+
   .grid__cell {
     border-right-color: var(--color-black);
     border-right-style: solid;

--- a/src/blog.webc
+++ b/src/blog.webc
@@ -1,6 +1,6 @@
 ---
 layout: layout.webc
-pageTitle: Blog
+title: Blog
 mainTitle: Blog
 ---
 

--- a/src/index.webc
+++ b/src/index.webc
@@ -1,6 +1,5 @@
 ---
 layout: layout.webc
-title: home
 mainTitle: I'm a software engineer, educator, and <span id="dynamic-title">slow Rubik's Cube solver</span>.
 subTitle: I specialise in <span class="strong">full-stack web development</span>, have a passion for <span class="strong">teaching</span>, and a dubious past as a <span class="strong">webcomic developer</span>. Like this website, I'm a continuous work in progress.
 ---

--- a/src/work.webc
+++ b/src/work.webc
@@ -1,6 +1,6 @@
 ---
 layout: layout.webc
-pageTitle: Work
+title: Work
 mainTitle: Work
 pagination:
   data: collections.works


### PR DESCRIPTION
Add script to the eleventy configuration so that the page title is automatically generated following a pattern.

If there's no title set for a certain page, the page title will be "Carlo Trimarchi | Software Engineer", otherwise it will be "<page title> | Carlo Trimarchi"